### PR TITLE
Fixes incorrect package reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const values = { name: 'j', password: 'z', confirmPassword: 'z' };
 (1) Convert the Joi messages to the form UI schema, retaining the original message text.
 
 ```javascript
-const joiToForms = require('joi-errors-to-forms').form;
+const joiToForms = require('joi-errors-for-forms').form;
 const convertToForms = joiToForms();
 
 Joi.validate(values, schema, joiOptions, (errs, convertedValues) => {
@@ -51,7 +51,7 @@ Joi.validate(values, schema, joiOptions, (errs, convertedValues) => {
 (2) Convert to the form UI schema. Replace Joi messages using Joi error types. (Recommended.)
 
 ```javascript
-const joiToForms = require('joi-errors-to-forms').form;
+const joiToForms = require('joi-errors-for-forms').form;
 const convertToForms = joiToForms({
   'string.min': () => i18n('"${key}" must be ${limit} or more chars.'),
   'string.regex.base': (context) => {
@@ -77,7 +77,7 @@ function i18n(str) { return str; } // internationalization
 or convert to the Mongoose schema.
 
 ```javascript
-const joiToMongoose = require('joi-errors-to-forms').mongoose;
+const joiToMongoose = require('joi-errors-for-forms').mongoose;
 const convertToMongoose = joiToMongoose({
   ... same as above ...
 });
@@ -174,11 +174,11 @@ You can then require the package.
 
 ```javascript
 // ES5
-var joiErrorsToForms = require('joi-errors-to-forms');
+var joiErrorsToForms = require('joi-errors-for-forms');
 var joiToForms = joiErrorsToForms.form;
 var joiToMongoose = joiErrorsToForms.mongoose;
 // or ES6
-import { form as joiToForms, mongoose as joiToMongoose } from 'joi-errors-to-forms';
+import { form as joiToForms, mongoose as joiToMongoose } from 'joi-errors-for-forms';
 ```
 
 ## API Reference


### PR DESCRIPTION
Unless I'm mistaken, README referenced incorrect joi-errors-to-forms not joi-errors-for-forms
