### PR TITLE
Guard against missing validation message

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,16 @@ function useJoiMsg(detail, options) {
 
 function useJoiType(detail, options) {
   var context = detail.context;
-  var message = options[detail.type](context) || detail.message;
+  var message;
+
+  if (options[detail.type]) {
+      message = options[detail.type](context)
+  }
+  
+  if (!message) {
+      message = detail.message;
+  }
+
   return substituteContext(context, message);
 }
 


### PR DESCRIPTION
Without this I get:

```
TypeError: options[detail.type] is not a function
    at useJoiType (index.js:87)
    at joiErrorsForFormsInner (index.js:51)
```

if I'm missing a type passed to `joiToForms`.