### PR TITLE
Fix issue 6. Join path with "." to handle deep path

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function joiErrorsForForms(format, options) {
     var newErrs = {};
     for (var i = 0, leni = joiErrs.details.length; i < leni; i++) {
       var detail = joiErrs.details[i];
-      var path = detail.path;
+      var path = detail.path.join('.');
 
       switch (format) {
         case 'mongoose':


### PR DESCRIPTION
To fix : https://github.com/eddyystop/joi-errors-for-forms/issues/6
When the path is an array we should join with dot to avoid having `field,subfield`.